### PR TITLE
feat: add TeleportToPlayerAction for player teleportation functionality

### DIFF
--- a/NookureStaff-Paper/src/main/java/com/nookure/staff/paper/inventory/action/TeleportToPlayerAction.java
+++ b/NookureStaff-Paper/src/main/java/com/nookure/staff/paper/inventory/action/TeleportToPlayerAction.java
@@ -1,0 +1,64 @@
+package com.nookure.staff.paper.inventory.action;
+
+import com.google.inject.Inject;
+import com.nookure.core.inv.paper.CustomPaperAction;
+import com.nookure.staff.api.Logger;
+import com.nookure.staff.api.PlayerWrapper;
+import com.nookure.staff.api.config.ConfigurationContainer;
+import com.nookure.staff.api.config.bukkit.BukkitMessages;
+import com.nookure.staff.api.manager.PlayerWrapperManager;
+import com.nookure.core.inv.paper.annotation.CustomActionData;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+@CustomActionData(value = "teleport_to_player", hasValue = true)
+public class TeleportToPlayerAction extends CustomPaperAction {
+  @Inject
+  private PlayerWrapperManager<Player> playerWrapperManager;
+  @Inject
+  private ConfigurationContainer<BukkitMessages> messages;
+  @Inject
+  private Logger logger;
+
+  @Override
+  public void execute(Player player, @Nullable String value) {
+    if (value == null) {
+      logger.warning("TeleportToPlayerAction called with null value");
+      return;
+    }
+
+    PlayerWrapper staffPlayer = playerWrapperManager.getPlayerWrapper(player.getUniqueId()).orElse(null);
+    if (staffPlayer == null) {
+      logger.warning("Staff player wrapper not found for " + player.getName());
+      return;
+    }
+
+    // The value can be either a player name or UUID
+    PlayerWrapper targetPlayer = null;
+    
+    // Try to parse as UUID first
+    try {
+      UUID targetUUID = UUID.fromString(value);
+      targetPlayer = playerWrapperManager.getPlayerWrapper(targetUUID).orElse(null);
+    } catch (IllegalArgumentException e) {
+      // Not a UUID, try to find by name
+      targetPlayer = playerWrapperManager.stream()
+          .filter(p -> p.getName().equalsIgnoreCase(value))
+          .findFirst()
+          .orElse(null);
+    }
+
+    if (targetPlayer == null) {
+      staffPlayer.sendMiniMessage(messages.get().playerNotFound(), "player", value);
+      return;
+    }
+
+    // Use native teleportation API
+    staffPlayer.teleport(targetPlayer);
+    staffPlayer.sendMiniMessage(messages.get().staffMode.teleportingTo(), "player", targetPlayer.getName());
+    
+    logger.debug("Teleported %s to %s using native API", staffPlayer.getName(), targetPlayer.getName());
+  }
+} 

--- a/NookureStaff-Paper/src/main/java/com/nookure/staff/paper/loader/InventoryLoader.java
+++ b/NookureStaff-Paper/src/main/java/com/nookure/staff/paper/loader/InventoryLoader.java
@@ -10,6 +10,7 @@ import com.nookure.staff.api.config.ConfigurationContainer;
 import com.nookure.staff.api.config.bukkit.BukkitConfig;
 import com.nookure.staff.api.util.AbstractLoader;
 import com.nookure.staff.api.util.JarUtil;
+import com.nookure.staff.paper.inventory.action.TeleportToPlayerAction;
 import com.nookure.staff.paper.inventory.extenion.DataFormatExtension;
 import com.nookure.staff.paper.inventory.extenion.NookurePlayerExtension;
 import com.nookure.staff.paper.pin.action.PinButtonPressed;
@@ -74,6 +75,9 @@ public class InventoryLoader implements AbstractLoader {
     if (config.get().modules.isPinCode()) {
       registry.registerAction(injector.getInstance(PinButtonPressed.class));
     }
+    
+    // Register native teleportation action
+    registry.registerAction(injector.getInstance(TeleportToPlayerAction.class));
   }
 
   @Override

--- a/NookureStaff-Paper/src/main/resources/inventories/player-list/actions.peb
+++ b/NookureStaff-Paper/src/main/resources/inventories/player-list/actions.peb
@@ -47,7 +47,7 @@
                 </LoreLine>
             </Lore>
             <Actions>
-                <Action type="RUN_COMMAND_AS_PLAYER" value="tp {{ player.name }}"/>
+                <Action type="teleport_to_player" value="{{ player.uniqueId }}"/>
                 <Action type="CLOSE_INVENTORY"/>
             </Actions>
         </Item>


### PR DESCRIPTION
This avoids having to give staff the `minecraft.command.teleport` permission, which they can easily abuse without being in staff mode.